### PR TITLE
Fix readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The provider should now be useable from within Terraform!
 
 ```
 provider "nrs" {
-  new_relic_api_key = "REDACTED"
+  newrelic_api_key = "REDACTED"
 }
 
 resource "nrs_monitor" "new_monitor" {


### PR DESCRIPTION
Removed erroneous underscore from new relic api key attribute in example.