### PR TITLE
Add import support for synthetics monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,3 +80,18 @@ resource "nrs_alert_condition" "new_condition" {
   policy_id = "${newrelic_alert_policy.new_policy.id}"
 }
 ```
+
+# Import
+
+In case of using import for alerts condition be aware that provider needs two value to do correct import.
+
+```
+terraform import name_of_resource policy_id:condition_id
+terraform import nrs_alert_condition.alert1 123456:567890
+```
+
+For importing monitors only id of monitor is needed:
+```
+terraform import name_of_resource monitor_id
+terraform import nrs_monitor.monitor1 d02c69d5-bac8-4243-91f4-4f9c62a7c71c
+```

--- a/pkg/provider/resource_nrs_alert_condition.go
+++ b/pkg/provider/resource_nrs_alert_condition.go
@@ -2,8 +2,8 @@ package provider
 
 import (
 	"fmt"
-        "strings"
-        "strconv"
+	"strconv"
+	"strings"
 
 	synthetics "github.com/dollarshaveclub/new-relic-synthetics-go"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -54,9 +54,9 @@ func NRSAlertConditionResource() *schema.Resource {
 		Delete: NRSAlertConditionDelete,
 		Read:   NRSAlertConditionRead,
 		Update: NRSAlertConditionUpdate,
-                Importer: &schema.ResourceImporter{
-                    State: NRSAlertConditionImportState,
-                },
+		Importer: &schema.ResourceImporter{
+			State: NRSAlertConditionImportState,
+		},
 	}
 }
 
@@ -83,22 +83,22 @@ func NRSAlertConditionCreate(resourceData *schema.ResourceData, meta interface{}
 
 	return nil
 }
-
-
+// NRSAlertConditionImportState imports given condition to Terraform state
+// using policy_id and condition_id from New Relic alerts API
 func NRSAlertConditionImportState(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-    s := strings.Split(d.Id(), ":")
-    if len(s) != 2 {
-        /*
-            In New Relic alert condition , we need both policy_id  and condition_id to get given user data.
-        */
-        return nil, fmt.Errorf("Import resource ID should consist of policy_id:condition_id")
-    }
+	s := strings.Split(d.Id(), ":")
+	if len(s) != 2 {
+		/*
+		   In New Relic alert condition , we need both policy_id  and condition_id to get given user data.
+		*/
+		return nil, fmt.Errorf("Import resource ID should consist of policy_id:condition_id")
+	}
 
-    val,_ := strconv.Atoi(s[0])
-    d.SetId(s[1])
-    d.Set("policy_id", val)
+	val, _ := strconv.Atoi(s[0])
+	d.SetId(s[1])
+	d.Set("policy_id", val)
 
-    return []*schema.ResourceData{d}, nil
+	return []*schema.ResourceData{d}, nil
 }
 
 // NRSAlertConditionExists checks whether an alert condition exists

--- a/pkg/provider/resource_nrs_alert_condition.go
+++ b/pkg/provider/resource_nrs_alert_condition.go
@@ -2,6 +2,8 @@ package provider
 
 import (
 	"fmt"
+        "strings"
+        "strconv"
 
 	synthetics "github.com/dollarshaveclub/new-relic-synthetics-go"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -52,6 +54,9 @@ func NRSAlertConditionResource() *schema.Resource {
 		Delete: NRSAlertConditionDelete,
 		Read:   NRSAlertConditionRead,
 		Update: NRSAlertConditionUpdate,
+                Importer: &schema.ResourceImporter{
+                    State: NRSAlertConditionImportState,
+                },
 	}
 }
 
@@ -77,6 +82,23 @@ func NRSAlertConditionCreate(resourceData *schema.ResourceData, meta interface{}
 	resourceData.SetId(fmt.Sprintf("%d", alertCondition.ID))
 
 	return nil
+}
+
+
+func NRSAlertConditionImportState(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+    s := strings.Split(d.Id(), ":")
+    if len(s) != 2 {
+        /*
+            In New Relic alert condition , we need both policy_id  and condition_id to get given user data.
+        */
+        return nil, fmt.Errorf("Import resource ID should consist of policy_id:condition_id")
+    }
+
+    val,_ := strconv.Atoi(s[0])
+    d.SetId(s[1])
+    d.Set("policy_id", val)
+
+    return []*schema.ResourceData{d}, nil
 }
 
 // NRSAlertConditionExists checks whether an alert condition exists

--- a/pkg/provider/resource_nrs_monitor.go
+++ b/pkg/provider/resource_nrs_monitor.go
@@ -111,6 +111,9 @@ func NRSMonitorResource() *schema.Resource {
 		Delete: NRSMonitorDelete,
 		Read:   NRSMonitorRead,
 		Update: NRSMonitorUpdate,
+                Importer: &schema.ResourceImporter{
+                    State: NRSMonitorImport,
+                },
 	}
 }
 
@@ -186,6 +189,12 @@ func NRSMonitorCreate(resourceData *schema.ResourceData, meta interface{}) error
 	}
 
 	return nil
+}
+
+func NRSMonitorImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+    d.SetId(d.Id())
+
+    return []*schema.ResourceData{d}, nil
 }
 
 // NRSMonitorUpdate updates a Synthetics monitor using Terraform

--- a/pkg/provider/resource_nrs_monitor.go
+++ b/pkg/provider/resource_nrs_monitor.go
@@ -112,7 +112,7 @@ func NRSMonitorResource() *schema.Resource {
 		Read:   NRSMonitorRead,
 		Update: NRSMonitorUpdate,
                 Importer: &schema.ResourceImporter{
-                    State: NRSMonitorImport,
+                    State: schema.ImportStatePassthrough,
                 },
 	}
 }
@@ -189,12 +189,6 @@ func NRSMonitorCreate(resourceData *schema.ResourceData, meta interface{}) error
 	}
 
 	return nil
-}
-
-func NRSMonitorImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-    d.SetId(d.Id())
-
-    return []*schema.ResourceData{d}, nil
 }
 
 // NRSMonitorUpdate updates a Synthetics monitor using Terraform

--- a/pkg/provider/resource_nrs_monitor.go
+++ b/pkg/provider/resource_nrs_monitor.go
@@ -111,9 +111,9 @@ func NRSMonitorResource() *schema.Resource {
 		Delete: NRSMonitorDelete,
 		Read:   NRSMonitorRead,
 		Update: NRSMonitorUpdate,
-                Importer: &schema.ResourceImporter{
-                    State: schema.ImportStatePassthrough,
-                },
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 	}
 }
 


### PR DESCRIPTION
With this change user can import monitors from New Relic
```
terraform import nrs_monitor.new_monitor2 d0224720-7d66-4c7d-b37b-c312ec8dedc0
nrs_monitor.new_monitor2: Importing from ID "d0224720-7d66-4c7d-b37b-c312ec8dedc0"...
nrs_monitor.new_monitor2: Import complete!
  Imported nrs_monitor (ID: d0224720-7d66-4c7d-b37b-c312ec8dedc0)
nrs_monitor.new_monitor2: Refreshing state... (ID: d0224720-7d66-4c7d-b37b-c312ec8dedc0)

Import successful! 
```