### PR TITLE
Remove `id` field as it's invalid with later Terraform SDK version(s).

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ tmp/*
 vendor
 build
 releases
+/.gtm/

--- a/pkg/provider/resource_nrs_alert_condition.go
+++ b/pkg/provider/resource_nrs_alert_condition.go
@@ -59,7 +59,7 @@ func schemaId(resourceData *schema.ResourceData) (int, error) {
 
 	iresid, err := strconv.Atoi(sresid)
 	if (err != nil) {
-		return -1, fmt.Errorf("error: could not determine/convert id from resourceData.Id()=\"%s\" to int.", sresid)
+		return -1, errors.Wrapf(err, "error: could not determine/convert id from resourceData.Id()=\"%s\" to int.", sresid)
 	}
 
 	return iresid, nil

--- a/pkg/provider/resource_nrs_monitor.go
+++ b/pkg/provider/resource_nrs_monitor.go
@@ -15,11 +15,6 @@ import (
 func NRSMonitorResource() *schema.Resource {
 	return &schema.Resource{
 		Schema: map[string]*schema.Schema{
-			"id": &schema.Schema{
-				Type:        schema.TypeString,
-				Computed:    true,
-				Description: "The monitor's ID with New Relic",
-			},
 			"name": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,


### PR DESCRIPTION
I did this fairly quickly to get this provider to run for me against terraform's `0.12` "sdk".

I'll have another PR to do that part itself (it will include this one).

Let me know if this looks alright to you -- at first glance and test it seems to work as expected so far.

Ty